### PR TITLE
fix in add_boundary_condition

### DIFF
--- a/Release_notes.txt
+++ b/Release_notes.txt
@@ -1,3 +1,10 @@
+What is new in version 1.1.4
+
+Bug fixes
+- dfm.py
+	- add_boundary_condition: pd.datetime.strftime() fixed 00: (hours) were missing, not accepted by D-Hydro interface 
+
+
 What is new in version 0.2.0
 
 Bug fixes

--- a/delft3dfmpy/core/dfm.py
+++ b/delft3dfmpy/core/dfm.py
@@ -230,7 +230,7 @@ class ExternalForcings:
         if isinstance(series, pd.Series):
             times = ((series.index - series.index[0]).total_seconds() / 60.).tolist()
             values = series.values.tolist()
-            startdate = pd.datetime.strftime(series.index[0],'%Y-%m-%d %M:%H:%S')
+            startdate = pd.datetime.strftime(series.index[0],'%Y-%m-%d %H:%M:%S')
         else:
             times = None
             values = series

--- a/delft3dfmpy/core/dfm.py
+++ b/delft3dfmpy/core/dfm.py
@@ -230,11 +230,11 @@ class ExternalForcings:
         if isinstance(series, pd.Series):
             times = ((series.index - series.index[0]).total_seconds() / 60.).tolist()
             values = series.values.tolist()
-            startdate = pd.datetime.strftime(series.index[0],'%Y%m%d')
+            startdate = pd.datetime.strftime(series.index[0],'%Y-%m-%d %M:%H:%S')
         else:
             times = None
             values = series
-            startdate = '0000000000'
+            startdate = '0000-00-00 00:00:00'
         
         # Add boundary condition
         self.boundaries[name] = {
@@ -245,7 +245,7 @@ class ExternalForcings:
             'filetype': 9,
             'operand': 'O',
             'method': 3,
-            'time_unit': f'minutes since {startdate[0:4]}-{startdate[4:6]}-{startdate[6:8]} {startdate[8:10]}:00:00',
+            'time_unit': f'minutes since {startdate}',
             'value_unit' : unit,            
             'nodeid': nodeid
         }


### PR DESCRIPTION
Issue with pd.datetime.strftime() fixed. 00: (hours) were missing in boundaries.bc and that is not accepted by D-Hydro gui